### PR TITLE
Github workflow added for auto-assign

### DIFF
--- a/.github/workflows/auto-issue-management.yml
+++ b/.github/workflows/auto-issue-management.yml
@@ -1,0 +1,30 @@
+name: Auto Issue Management
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  manage-issue:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      repository-projects: write
+    steps:
+      - name: Add to Project
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/users/gopikrishee/projects/2
+          github-token: ${{ secrets.PROJECT_TOKEN }}
+          issue-url: ${{ github.event.issue.html_url }}
+
+      - name: Assign to gopikrishee
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: ['gopikrishee']
+            })


### PR DESCRIPTION
Whenever new issue added, it should automatically moved to Portfolio Backend project backlogs and assign to myself